### PR TITLE
Add transformation operations to materialize helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Types of changes are:
 * **Fixed** for any bug fixes.
 
 ## [Unreleased]
+### Added
+* Three new optional parameters to `materialize`:
+    - `include_keys` - set of keys to include in the materialized
+      document.
+    - `exclude_keys` - set of keys to exclude from the materialized
+      document.
+    - `value_map` - operation to apply to items of the document.
 
 ## [0.2.1] - 2019-12-06
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ assert isinstance(schema, dict)
 
 A materialized `RefDict` is just a regular dict, containing a document with all references resolved. This is useful if, for example, you want to cache/persist the entire schema. Be aware that if there are cyclical references in the schema, these will be present on the materialized dictionary.
 
+The `materialize` helper also supports some basic transformation options, as performing global transformations on infinite documents is non-trivial:
+
+- `include_keys` - an iterable of keys to include in the materialized document.
+- `exclude_keys` - an iterable of keys to exclude from the materialized document.
+- `value_map` - an operation to apply to the values of the document (not lists or dictionaries).
+
 # Requirements
 This package is currently tested for Python 3.6.
 

--- a/tests/test_materialize.py
+++ b/tests/test_materialize.py
@@ -36,3 +36,39 @@ def test_materialize_circular_ref():
         dictionary["definitions"]
         == dictionary["definitions"]["foo"]["definitions"]
     )
+
+
+def test_materialize_document_exclude_keys():
+    ref_dict = RefDict("tests/schemas/master.yaml#/")
+    dictionary = materialize(ref_dict, exclude_keys={"remote_ref"})
+    assert isinstance(dictionary, dict)
+    assert dictionary == {
+        "definitions": {
+            "foo": {"type": "string"},
+            "local_ref": {"type": "string"},
+            "backref": {"type": "string"},
+        }
+    }
+
+
+def test_materialize_document_include_keys():
+    ref_dict = RefDict("tests/schemas/master.yaml#/")
+    dictionary = materialize(
+        ref_dict, include_keys={"remote_ref", "definitions", "type"}
+    )
+    assert isinstance(dictionary, dict)
+    assert dictionary == {"definitions": {"remote_ref": {"type": "integer"}}}
+
+
+def test_materialize_document_value_map():
+    ref_dict = RefDict("tests/schemas/master.yaml#/")
+    dictionary = materialize(ref_dict, value_map=len)
+    assert isinstance(dictionary, dict)
+    assert dictionary == {
+        "definitions": {
+            "foo": {"type": 6},
+            "local_ref": {"type": 6},
+            "remote_ref": {"type": 7},
+            "backref": {"type": 6},
+        }
+    }


### PR DESCRIPTION
### Added
* Three new optional parameters to `materialize`:
    - `include_keys` - set of keys to include in the materialized
      document.
    - `exclude_keys` - set of keys to exclude from the materialized
      document.
    - `value_map` - operation to apply to items of the document.


# Check list

## Before asking for a review

- [x] Target branch is `master`
- [x] `make test` passes locally.
- [x] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [x] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [ ] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [ ] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.