### PR TITLE
Add context labelling option to materialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Types of changes are:
 * **Fixed** for any bug fixes.
 
 ## [Unreleased]
+### Added
+* New optional parameter to `materialize`:
+    - `context_labeller` - factory for generating annotation on
+      objects in the document from their source URI.
 
 ## [0.3.0] - 2019-12-10
 ### Added

--- a/tests/test_materialize.py
+++ b/tests/test_materialize.py
@@ -122,3 +122,11 @@ def test_materialize_uri_label():
             },
         },
     }
+
+
+def test_materialize_name_label_circular():
+    ref_dict = RefDict("tests/schemas/circular.yaml#/")
+    dictionary = materialize(ref_dict, context_labeller=name_label)
+    assert isinstance(dictionary, dict)
+    assert dictionary["definitions"]["title"] == "definitions"
+    assert dictionary["definitions"]["foo"]["title"] == "#"


### PR DESCRIPTION
* New optional parameter to `materialize`:
    - `context_labeller` - factory for generating annotation on
      objects in the document from their source URI.

# Check list

## Before asking for a review

- [x] Target branch is `master`
- [x] `make test` passes locally.
- [x] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [x] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [ ] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [ ] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.