### PR TITLE
Fix URI parsing without pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Types of changes are:
 * **Fixed** for any bug fixes.
 
 ## [Unreleased]
+### Fixed
+* Fixed issue where pure address references with no pointers
+  are rejected.
+* Fixed issue with relative remote references independent of a
+  base absolute URI.
 
 ## [0.4.0] - 2019-12-10
 ### Added

--- a/json_ref_dict/uri.py
+++ b/json_ref_dict/uri.py
@@ -19,6 +19,10 @@ class URI(NamedTuple):
     @classmethod
     def from_string(cls, string: str) -> "URI":
         """Contruct from string."""
+        if "#" not in string:
+            string += "#/"
+        if string.endswith("#"):
+            string += "/"
         match = re.match(JSON_REF_REGEX, string)
         if not match:
             raise ReferenceParseError(
@@ -32,7 +36,7 @@ class URI(NamedTuple):
     @property
     def root(self):
         """String representation excluding the JSON pointer."""
-        return path.join(self.uri_base, self.uri_name)
+        return path.join(*filter(None, [self.uri_base, self.uri_name]))
 
     def _get_relative(self, reference: str) -> "URI":
         """Get a new URI relative to the current root."""
@@ -42,7 +46,9 @@ class URI(NamedTuple):
             reference = reference.split("#")[1] or "/"
             return URI(self.uri_base, self.uri_name, reference)
         # Remote reference.
-        return self.from_string(path.join(self.uri_base, reference))
+        return self.from_string(
+            path.join(*filter(None, [self.uri_base, reference]))
+        )
 
     def relative(self, reference: str) -> "URI":
         """Get a new URI relative to the current root.
@@ -77,4 +83,4 @@ class URI(NamedTuple):
 
     def __repr__(self) -> str:
         """String representation of the URI."""
-        return path.join(self.uri_base, self.uri_name) + f"#{self.pointer}"
+        return self.root + f"#{self.pointer}"

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -4,12 +4,16 @@ from json_ref_dict import URI
 from json_ref_dict.exceptions import ReferenceParseError
 
 
-@pytest.mark.parametrize(
-    "reference", ["foobar", "foobar#", "foobar#definitions", "#definitions"]
-)
+@pytest.mark.parametrize("reference", ["foobar#definitions", "#definitions"])
 def test_from_string_fails_for_bad_references(reference: str):
     with pytest.raises(ReferenceParseError):
         _ = URI.from_string(reference)
+
+
+@pytest.mark.parametrize("reference", ["foobar", "foobar#"])
+def test_from_string_modifies_bad_references(reference: str):
+    uri = URI.from_string(reference)
+    assert str(uri).endswith("#/")
 
 
 def test_relative_raises_type_error_if_passed_bad_reference():


### PR DESCRIPTION
Any related Github Issues?: _add link here_ 

### Fixed
* Fixed issue where pure address references with no pointers
  are rejected.
* Fixed issue with relative remote references independent of a
  base absolute URI.

# Check list

## Before asking for a review

- [x] Target branch is `master`
- [x] `make test` passes locally.
- [x] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [x] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [ ] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [ ] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.