### PR TITLE
Feature/ref to primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Types of changes are:
 * **Fixed** for any bug fixes.
 
 ## [Unreleased]
+### Fixed
+* References to lists and primitive data types now works
+  when traversing `RefDict` and `RefList` objects.
+* Spaces and newlines now allowed in JSON keys.
 
 ## [0.5.0] - 2020-03-20
 ### Added

--- a/json_ref_dict/ref_dict.py
+++ b/json_ref_dict/ref_dict.py
@@ -59,7 +59,21 @@ def propagate(uri: URI, value: Any):
     """Ref resolution and propagation of behaviours on __getitem__."""
     if isinstance(value, dict):
         if "$ref" in value and isinstance(value["$ref"], str):
-            return RefDict(uri.relative(value["$ref"]))
+            return _from_uri(uri.relative(value["$ref"]))
+        return RefDict(uri)
+    if isinstance(value, list):
+        return RefList(uri)
+    return value
+
+
+def _from_uri(uri: URI):
+    """Convert URI to corresponding data type.
+
+    Looks ahead at the raw value, and then returns a RefDict, RefList, or
+    other value.
+    """
+    value = resolve_uri(uri)
+    if isinstance(value, dict):
         return RefDict(uri)
     if isinstance(value, list):
         return RefList(uri)

--- a/json_ref_dict/ref_pointer.py
+++ b/json_ref_dict/ref_pointer.py
@@ -1,15 +1,12 @@
 from collections import abc
 from functools import lru_cache
-from typing import Any, Dict, List, NoReturn, Optional, Tuple, TypeVar, Union
+from typing import Any, Dict, List, NoReturn, Optional, Tuple, Union
 
 from jsonpointer import JsonPointer, JsonPointerException, _nothing
 
 from json_ref_dict.exceptions import DocumentParseError
 from json_ref_dict.loader import get_document
 from json_ref_dict.uri import URI
-
-
-T = TypeVar("T", List, Dict, int, float, str, bool, None)
 
 
 class RefPointer(JsonPointer):
@@ -86,7 +83,7 @@ class RefPointer(JsonPointer):
 
 
 @lru_cache(maxsize=None)
-def resolve_uri(uri: URI) -> T:
+def resolve_uri(uri: URI) -> Union[List, Dict, None, bool, str, int, float]:
     """Find the value for a given URI.
 
     Loads the document and resolves the pointer, bypsasing refs.

--- a/json_ref_dict/uri.py
+++ b/json_ref_dict/uri.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 from json_ref_dict.exceptions import ReferenceParseError
 
 
-JSON_REF_REGEX = r"^((?P<uri_base>.*)\/)?(?P<uri_name>.*)#(?P<pointer>\/.*)$"
+JSON_REF_REGEX = r"^((?P<uri_base>.*)\/)?(?P<uri_name>.*)#(?P<pointer>\/.*)"
 
 
 class URI(NamedTuple):
@@ -23,7 +23,7 @@ class URI(NamedTuple):
             string += "#/"
         if string.endswith("#"):
             string += "/"
-        match = re.match(JSON_REF_REGEX, string)
+        match = re.match(JSON_REF_REGEX, string, re.DOTALL)
         if not match:
             raise ReferenceParseError(
                 f"Couldn't parse '{string}' as a valid reference. "

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -124,7 +124,6 @@ class TestResolveURI:
         assert result == "bar"
 
     @staticmethod
-    @pytest.mark.foo
     def test_get_uri_with_newline():
         uri = URI.from_string("base/with-newline.json#/top/with\nnewline")
         result = resolve_uri(uri)

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -47,6 +47,12 @@ TEST_DATA = {
             "ref\nto\nnewline": {"$ref": "#/top/with\nnewline"},
         }
     },
+    "base/ref-to-primitive.json": {
+        "top": {
+            "primitive": "foo",
+            "ref_to_primitive": {"$ref": "#/top/primitive"},
+        }
+    },
 }
 
 
@@ -208,6 +214,12 @@ class TestRefDict:
         pointer = JsonPointer("/definitions/foo/not/0")
         assert pointer.resolve(ref_dict) == {"type": "object"}
 
+    @staticmethod
+    def test_dict_with_ref_to_primitive():
+        ref_dict = RefDict("base/ref-to-primitive.json#/")
+        assert ref_dict["top"]["primitive"] == "foo"
+        assert ref_dict["top"]["ref_to_primitive"] == "foo"
+
 
 class TestRefPointer:
     @staticmethod
@@ -306,3 +318,18 @@ class TestRefPointer:
         assert RefPointer(uri.get("nonexistent")).resolve(
             document, default=default
         )
+
+    @staticmethod
+    def test_ref_pointer_returns_non_dict_values(
+        uri: URI, document: Dict[str, Any]
+    ):
+        uri = uri.get("definitions").get("foo").get("type")
+        assert RefPointer(uri).resolve(document) == "string"
+
+    @staticmethod
+    def test_ref_to_primitive():
+        uri = URI.from_string(
+            "base/ref-to-primitive.json#/top/ref_to_primitive"
+        )
+        document = get_document(uri.root)
+        assert RefPointer(uri).resolve(document) == "foo"

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -35,6 +35,18 @@ TEST_DATA = {
         }
     },
     "base/nonref.json": {"definitions": {"$ref": {"type": "string"}}},
+    "base/with-spaces.json": {
+        "top": {
+            "with spaces": {"foo": "bar"},
+            "ref to spaces": {"$ref": "#/top/with spaces"},
+        }
+    },
+    "base/with-newline.json": {
+        "top": {
+            "with\nnewline": {"foo": "bar"},
+            "ref\nto\nnewline": {"$ref": "#/top/with\nnewline"},
+        }
+    },
 }
 
 
@@ -92,6 +104,33 @@ class TestResolveURI:
         non_ref_uri = URI.from_string("base/nonref.json#/definitions")
         non_ref = resolve_uri(non_ref_uri)
         assert non_ref["$ref"] == {"type": "string"}
+
+    @staticmethod
+    def test_get_uri_with_spaces():
+        uri = URI.from_string("base/with-spaces.json#/top/with spaces")
+        result = resolve_uri(uri)
+        assert result == {"foo": "bar"}
+
+    @staticmethod
+    def test_get_ref_with_spaces():
+        uri = URI.from_string("base/with-spaces.json#/top/ref to spaces/foo")
+        result = resolve_uri(uri)
+        assert result == "bar"
+
+    @staticmethod
+    @pytest.mark.foo
+    def test_get_uri_with_newline():
+        uri = URI.from_string("base/with-newline.json#/top/with\nnewline")
+        result = resolve_uri(uri)
+        assert result == {"foo": "bar"}
+
+    @staticmethod
+    def test_get_ref_with_newline():
+        uri = URI.from_string(
+            "base/with-newline.json#/top/ref\nto\nnewline/foo"
+        )
+        result = resolve_uri(uri)
+        assert result == "bar"
 
 
 class TestRefDict:


### PR DESCRIPTION
Any related Github Issues?: #15 
### Fixed
* References to lists and primitive data types now works
  when traversing `RefDict` and `RefList` objects.
* Spaces and newlines now allowed in JSON keys.

# Check list

## Before asking for a review

- [x] Target branch is `master`
- [x] `make test` passes locally.
- [x] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [x] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [ ] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [ ] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.