### PR TITLE
Fix immediate references in resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Types of changes are:
 * **Fixed** for any bug fixes.
 
 ## [Unreleased]
+### Fixed
+* Resolving a URI with an immediate reference now correctly
+  resolves that reference.
 
 ## [0.5.1] - 2020-03-31
 ### Fixed

--- a/json_ref_dict/ref_pointer.py
+++ b/json_ref_dict/ref_pointer.py
@@ -52,6 +52,11 @@ class RefPointer(JsonPointer):
         :raises JsonPointerException: if `default` is not set and pointer
             could not be resolved.
         """
+        if not list(filter(None, self.parts)):
+            # Handle immediate refs with no pointer.
+            has_remote, remote = self.resolve_remote(doc, 0)
+            if has_remote:
+                return remote
         for idx, part in enumerate(self.parts):
             if not part:
                 continue

--- a/tests/schemas/immediate-ref.json
+++ b/tests/schemas/immediate-ref.json
@@ -1,0 +1,1 @@
+{"$ref": "other.yaml#/definitions/bar"}

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -58,7 +58,6 @@ TEST_DATA = {
             "to_array": {"$ref": "#/array"},
             "to_object": {"$ref": "#/object"},
             "to_primitive": {"$ref": "#/primitive"},
-            "to_ref": {"$ref": "#/ref"},
         },
         "array": [1, 2, 3],
         "object": {"foo": "bar"},

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -83,3 +83,8 @@ class TestRefDictIORefs:
 def test_immediately_circular_reference_fails():
     with pytest.raises(ReferenceParseError):
         _ = RefDict("tests/schemas/bad-circular.yaml#/definitions/foo")
+
+
+def test_immediate_references_is_detected():
+    value = RefDict.from_uri("tests/schemas/immediate-ref.json")
+    assert value == {"type": "integer"}


### PR DESCRIPTION
### Fixed
* Resolving a URI with an immediate reference now correctly
  resolves that reference.

# Check list

## Before asking for a review

- [x] Target branch is `master`
- [x] `make test` passes locally.
- [x] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [x] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [ ] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [ ] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.