### PR TITLE
Feature/allow urlencoded chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Types of changes are:
 * **Fixed** for any bug fixes.
 
 ## [Unreleased]
+### Added
+* Added support for URL encoded characters in references.
+  `RefPointer` will now attempt the pointer segment as is,
+  and fallback to the decoded version if that fails.
 
 ## [0.5.3] - 2020-04-04
 ### Fixed

--- a/json_ref_dict/ref_pointer.py
+++ b/json_ref_dict/ref_pointer.py
@@ -1,6 +1,7 @@
 from collections import abc
 from functools import lru_cache
 from typing import Any, Dict, List, NoReturn, Optional, Tuple, Union
+from urllib.parse import unquote
 
 from jsonpointer import JsonPointer, JsonPointerException, _nothing
 
@@ -59,7 +60,10 @@ class RefPointer(JsonPointer):
             if not part:
                 continue
             try:
-                doc = self.walk(doc, part)
+                try:
+                    doc = self.walk(doc, part)
+                except JsonPointerException:
+                    doc = self.walk(doc, unquote(part))
                 has_remote, remote = self.resolve_remote(doc, idx)
                 if has_remote:
                     return remote

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -134,15 +134,21 @@ class TestResolveURI:
         assert non_ref["$ref"] == {"type": "string"}
 
     @staticmethod
-    def test_get_uri_with_spaces():
-        uri = URI.from_string("base/with-spaces.json#/top/with spaces")
+    @pytest.mark.parametrize(
+        "reference",
+        [
+            "base/with-spaces.json#/top/with spaces",
+            "base/with-spaces.json#/top/with%20spaces",
+        ],
+    )
+    def test_get_uri_with_spaces(reference: str):
+        uri = URI.from_string(reference)
         result = resolve_uri(uri)
         assert result == {"foo": "bar"}
 
     @staticmethod
     @pytest.mark.parametrize(
-        "base",
-        ["base/with-spaces.json", "base/with-spaces-encoded.json"]
+        "base", ["base/with-spaces.json", "base/with-spaces-encoded.json"]
     )
     def test_get_ref_with_spaces(base: str):
         uri = URI.from_string(f"{base}#/top/ref to spaces/foo")
@@ -150,20 +156,24 @@ class TestResolveURI:
         assert result == "bar"
 
     @staticmethod
-    def test_get_uri_with_newline():
-        uri = URI.from_string("base/with-newline.json#/top/with\nnewline")
+    @pytest.mark.parametrize(
+        "reference",
+        [
+            "base/with-newline.json#/top/with\nnewline",
+            "base/with-newline.json#/top/with%0Anewline",
+        ],
+    )
+    def test_get_uri_with_newline(reference: str):
+        uri = URI.from_string(reference)
         result = resolve_uri(uri)
         assert result == {"foo": "bar"}
 
     @staticmethod
     @pytest.mark.parametrize(
-        "base",
-        ["base/with-newline.json", "base/with-newline-encoded.json"]
+        "base", ["base/with-newline.json", "base/with-newline-encoded.json"]
     )
     def test_get_ref_with_newline(base: str):
-        uri = URI.from_string(
-            f"{base}#/top/ref\nto\nnewline/foo"
-        )
+        uri = URI.from_string(f"{base}#/top/ref\nto\nnewline/foo")
         result = resolve_uri(uri)
         assert result == "bar"
 

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -65,6 +65,16 @@ TEST_DATA = {
             "ref_to_primitive": {"$ref": "#/top/primitive"},
         }
     },
+    "base/with-escaped-chars.json": {
+        "tilda~field": {"type": "integer"},
+        "slash/field": {"type": "integer"},
+        "percent%field": {"type": "integer"},
+        "properties": {
+            "tilda": {"$ref": "#/tilda~0field"},
+            "slash": {"$ref": "#/slash~1field"},
+            "percent": {"$ref": "#/percent%25field"},
+        },
+    },
     "base/from-uri.json": {
         "refs": {
             "to_array": {"$ref": "#/array"},
@@ -176,6 +186,15 @@ class TestResolveURI:
         uri = URI.from_string(f"{base}#/top/ref\nto\nnewline/foo")
         result = resolve_uri(uri)
         assert result == "bar"
+
+    @staticmethod
+    @pytest.mark.parametrize("field", ["tilda", "slash", "percent",])
+    def test_get_ref_with_escaped_chars(field: str):
+        uri = URI.from_string(
+            f"base/with-escaped-chars.json#/properties/{field}"
+        )
+        result = resolve_uri(uri)
+        assert result == {"type": "integer"}
 
 
 class TestRefDict:

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -41,10 +41,22 @@ TEST_DATA = {
             "ref to spaces": {"$ref": "#/top/with spaces"},
         }
     },
+    "base/with-spaces-encoded.json": {
+        "top": {
+            "with spaces": {"foo": "bar"},
+            "ref to spaces": {"$ref": "#/top/with%20spaces"},
+        }
+    },
     "base/with-newline.json": {
         "top": {
             "with\nnewline": {"foo": "bar"},
             "ref\nto\nnewline": {"$ref": "#/top/with\nnewline"},
+        }
+    },
+    "base/with-newline-encoded.json": {
+        "top": {
+            "with\nnewline": {"foo": "bar"},
+            "ref\nto\nnewline": {"$ref": "#/top/with%0Anewline"},
         }
     },
     "base/ref-to-primitive.json": {
@@ -128,8 +140,12 @@ class TestResolveURI:
         assert result == {"foo": "bar"}
 
     @staticmethod
-    def test_get_ref_with_spaces():
-        uri = URI.from_string("base/with-spaces.json#/top/ref to spaces/foo")
+    @pytest.mark.parametrize(
+        "base",
+        ["base/with-spaces.json", "base/with-spaces-encoded.json"]
+    )
+    def test_get_ref_with_spaces(base: str):
+        uri = URI.from_string(f"{base}#/top/ref to spaces/foo")
         result = resolve_uri(uri)
         assert result == "bar"
 
@@ -140,9 +156,13 @@ class TestResolveURI:
         assert result == {"foo": "bar"}
 
     @staticmethod
-    def test_get_ref_with_newline():
+    @pytest.mark.parametrize(
+        "base",
+        ["base/with-newline.json", "base/with-newline-encoded.json"]
+    )
+    def test_get_ref_with_newline(base: str):
         uri = URI.from_string(
-            "base/with-newline.json#/top/ref\nto\nnewline/foo"
+            f"{base}#/top/ref\nto\nnewline/foo"
         )
         result = resolve_uri(uri)
         assert result == "bar"


### PR DESCRIPTION

### Added
* Added support for URL encoded characters in references.
  `RefPointer` will now attempt the pointer segment as is,
  and fallback to the decoded version if that fails.

# Check list

## Before asking for a review

- [x] Target branch is `master`
- [x] `make test` passes locally.
- [x] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [x] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [ ] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [ ] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.