### PR TITLE
Fix Windows path handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ Types of changes are:
 * **Fixed** for any bug fixes.
 
 ## [Unreleased]
+### Fixed
+* Fixed Windows path handling, changing all references of
+  path.join to posixpath.join, using pathlib to create
+  file:// paths, and circumventing Python bug 42215
+  with urllib.parse.urlparse mishandling Windows paths.
+* Setup.py was importing the package itself, causing
+  exceptions when installing by source. Following best
+  practices, a regex is used to extract the version from
+  the source code. 
 
 ## [0.6.0] - 2020-04-17
 ### Added

--- a/json_ref_dict/loader.py
+++ b/json_ref_dict/loader.py
@@ -42,7 +42,7 @@ def _read_document_content(base_uri: str) -> Dict[str, Any]:
     `urllib.request.urlopen`.
     :return: Raw content found at the URI.
     """
-    if os.name == 'nt' and path.isfile(base_uri) and path.isabs(base_uri):
+    if os.name == "nt" and path.isfile(base_uri) and path.isabs(base_uri):
         # https://bugs.python.org/issue42215
         # Windows paths drives are incorrectly detected as an uri schema, check if is an existing file
         # and convert to file://

--- a/json_ref_dict/loader.py
+++ b/json_ref_dict/loader.py
@@ -1,4 +1,5 @@
 import cgi
+import os
 import pathlib
 import posixpath
 from functools import lru_cache
@@ -41,6 +42,11 @@ def _read_document_content(base_uri: str) -> Dict[str, Any]:
     `urllib.request.urlopen`.
     :return: Raw content found at the URI.
     """
+    if os.name == 'nt' and path.isfile(base_uri) and path.isabs(base_uri):
+        # https://bugs.python.org/issue42215
+        # Windows paths drives are incorrectly detected as an uri schema, check if is an existing file
+        # and convert to file://
+        base_uri = pathlib.Path(base_uri).as_uri()
     url = urlparse(base_uri)
     if not url.scheme:
         prefix = "" if base_uri.startswith("/") else getcwd()

--- a/json_ref_dict/loader.py
+++ b/json_ref_dict/loader.py
@@ -1,4 +1,6 @@
 import cgi
+import pathlib
+import posixpath
 from functools import lru_cache
 import json
 import mimetypes
@@ -42,7 +44,7 @@ def _read_document_content(base_uri: str) -> Dict[str, Any]:
     url = urlparse(base_uri)
     if not url.scheme:
         prefix = "" if base_uri.startswith("/") else getcwd()
-        base_uri = "file://" + path.join(prefix, base_uri)
+        base_uri = pathlib.Path(posixpath.join(prefix, base_uri)).as_uri()
     with urlopen(base_uri) as conn:
         loader = _get_loader(conn)
         content = loader(conn)

--- a/json_ref_dict/loader.py
+++ b/json_ref_dict/loader.py
@@ -44,8 +44,8 @@ def _read_document_content(base_uri: str) -> Dict[str, Any]:
     """
     if os.name == "nt" and path.isfile(base_uri) and path.isabs(base_uri):
         # https://bugs.python.org/issue42215
-        # Windows paths drives are incorrectly detected as an uri schema, check if is an existing file
-        # and convert to file://
+        # Windows paths drives are incorrectly detected as an uri schema, check
+        # if is an existing file and convert to file://
         base_uri = pathlib.Path(base_uri).as_uri()
     url = urlparse(base_uri)
     if not url.scheme:

--- a/json_ref_dict/materialize.py
+++ b/json_ref_dict/materialize.py
@@ -1,3 +1,4 @@
+import posixpath
 from os import path
 from typing import (
     Any,
@@ -37,7 +38,7 @@ def _next_path(current_path: str) -> Callable[[str], str]:
     """
 
     def _wrap(segment: str):
-        return path.join(current_path, segment)
+        return posixpath.join(current_path, segment)
 
     return _wrap
 

--- a/json_ref_dict/materialize.py
+++ b/json_ref_dict/materialize.py
@@ -1,5 +1,4 @@
 import posixpath
-from os import path
 from typing import (
     Any,
     Callable,

--- a/json_ref_dict/uri.py
+++ b/json_ref_dict/uri.py
@@ -1,3 +1,4 @@
+import posixpath
 from os import path
 import re
 from typing import NamedTuple
@@ -36,7 +37,7 @@ class URI(NamedTuple):
     @property
     def root(self):
         """String representation excluding the JSON pointer."""
-        return path.join(*filter(None, [self.uri_base, self.uri_name]))
+        return posixpath.join(*filter(None, [self.uri_base, self.uri_name]))
 
     def _get_relative(self, reference: str) -> "URI":
         """Get a new URI relative to the current root."""
@@ -47,7 +48,7 @@ class URI(NamedTuple):
             return URI(self.uri_base, self.uri_name, reference)
         # Remote reference.
         return self.from_string(
-            path.join(*filter(None, [self.uri_base, reference]))
+            posixpath.join(*filter(None, [self.uri_base, reference]))
         )
 
     def relative(self, reference: str) -> "URI":
@@ -73,13 +74,13 @@ class URI(NamedTuple):
         return self.__class__(
             uri_base=self.uri_base,
             uri_name=self.uri_name,
-            pointer=path.join(self.pointer, *pointer_segments),
+            pointer=posixpath.join(self.pointer, *pointer_segments),
         )
 
     def back(self) -> "URI":
         """Pop a segment from the pointer."""
         segments = self.pointer.split("/")
-        pointer = path.join("/", *segments[:-1])
+        pointer = posixpath.join("/", *segments[:-1])
         return self.__class__(
             uri_base=self.uri_base, uri_name=self.uri_name, pointer=pointer
         )

--- a/json_ref_dict/uri.py
+++ b/json_ref_dict/uri.py
@@ -1,5 +1,4 @@
 import posixpath
-from os import path
 import re
 from typing import NamedTuple
 from urllib.parse import urlparse

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ from setuptools import find_packages, setup
 
 __version__ = re.search(
     r'__version__\s*=\s*[\'"]([^\'"]*)[\'"]',  # It excludes inline comment too
-    open('json_ref_dict/__init__.py', encoding='utf_8_sig').read()
-    ).group(1)
+    open("json_ref_dict/__init__.py", encoding="utf_8_sig").read(),
+).group(1)
 
 
 REQUIREMENTS_FILE_PATH = path.join(

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,17 @@ See:
 https://packaging.python.org/en/latest/distributing.html
 https://github.com/pypa/sampleproject
 """
-
+import re
 from codecs import open
 from os import path
 
 from setuptools import find_packages, setup
 
-import json_ref_dict
+
+__version__ = re.search(
+    r'__version__\s*=\s*[\'"]([^\'"]*)[\'"]',  # It excludes inline comment too
+    open('json_ref_dict/__init__.py', encoding='utf_8_sig').read()
+    ).group(1)
 
 
 REQUIREMENTS_FILE_PATH = path.join(
@@ -29,7 +33,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="json-ref-dict",
-    version=json_ref_dict.__version__,
+    version=__version__,
     description=(
         "Python dict-like object which abstracts resolution of "
         "JSONSchema references"

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -188,7 +188,14 @@ class TestResolveURI:
         assert result == "bar"
 
     @staticmethod
-    @pytest.mark.parametrize("field", ["tilda", "slash", "percent",])
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "tilda",
+            "slash",
+            "percent",
+        ],
+    )
     def test_get_ref_with_escaped_chars(field: str):
         uri = URI.from_string(
             f"base/with-escaped-chars.json#/properties/{field}"

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -25,7 +25,10 @@ class TestRefDictIORefs:
             posixpath.join(getcwd(), "tests/schemas/master.yaml#/definitions"),
             # explicit file scheme
             (
-                pathlib.Path(posixpath.join(getcwd(), "tests/schemas/master.yaml")).as_uri() + "#/definitions"
+                pathlib.Path(
+                    posixpath.join(getcwd(), "tests/schemas/master.yaml")
+                ).as_uri()
+                + "#/definitions"
             ),
             # https URI
             PINNED_FILE_URL + "#/definitions",

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,3 +1,5 @@
+import pathlib
+import posixpath
 from os import getcwd, path
 
 import pytest
@@ -23,8 +25,7 @@ class TestRefDictIORefs:
             path.join(getcwd(), "tests/schemas/master.yaml#/definitions"),
             # explicit file scheme
             (
-                "file://"
-                + path.join(getcwd(), "tests/schemas/master.yaml#/definitions")
+                pathlib.Path(posixpath.join(getcwd(), "tests/schemas/master.yaml#/definitions")).as_uri()
             ),
             # https URI
             PINNED_FILE_URL + "#/definitions",

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -22,10 +22,10 @@ class TestRefDictIORefs:
             # relative filepath
             "tests/schemas/master.yaml#/definitions",
             # absolute filepath
-            path.join(getcwd(), "tests/schemas/master.yaml#/definitions"),
+            posixpath.join(getcwd(), "tests/schemas/master.yaml#/definitions"),
             # explicit file scheme
             (
-                pathlib.Path(posixpath.join(getcwd(), "tests/schemas/master.yaml#/definitions")).as_uri()
+                pathlib.Path(posixpath.join(getcwd(), "tests/schemas/master.yaml")).as_uri() + "#/definitions"
             ),
             # https URI
             PINNED_FILE_URL + "#/definitions",

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,6 +1,6 @@
 import pathlib
 import posixpath
-from os import getcwd, path
+from os import getcwd
 
 import pytest
 


### PR DESCRIPTION
Any related Github Issues?: #2 

_What has changed? This should mimic `CHANGELOG.md`._
### Fixed
* Fixed Windows path handling, changing all references of
  path.join to posixpath.join, using pathlib to create
  file:// paths, and circumventing Python bug 42215
  with urllib.parse.urlparse mishandling Windows paths.
* Setup.py was importing the package itself, causing
  exceptions when installing by source. Following best
  practices, a regex is used to extract the version from
  the source code. 

# Check list

## Before asking for a review

- [X] Target branch is `master`
- [X] `make test` passes locally.
- [X] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [X] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [x] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [x] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.