### PR TITLE
Pluggable loaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Types of changes are:
 * **Fixed** for any bug fixes.
 
 ## [Unreleased]
+### Changed
+* `get_document` can now delegate the loading of a document to loaders.
+  `loaders` are registerable and can be chained until a document is
+  actually loaded. This allows several usecases : user/password secured
+  URL, local schema registry, special file handling...
+  The change is backward compatible and shouldn't impact existing
+  deployments.
 
 ## [0.6.2] - 2021-04-01
 ### Fixed
@@ -27,7 +34,7 @@ Types of changes are:
 * Setup.py was importing the package itself, causing
   exceptions when installing by source. Following best
   practices, a regex is used to extract the version from
-  the source code. 
+  the source code.
 
 ## [0.6.0] - 2020-04-17
 ### Added

--- a/json_ref_dict/loader.py
+++ b/json_ref_dict/loader.py
@@ -21,7 +21,7 @@ DocumentLoader = Callable[[str], JSONSchema]
 try:
     import yaml
 
-    CONTENT_PARSER: Parser = yaml.safe_load  # pragma: no cover
+    CONTENT_PARSER: Parser = yaml.safe_load
 except ImportError:  # pragma: no cover
     CONTENT_PARSER: Parser = json.load  # type: ignore
 
@@ -41,13 +41,13 @@ class Loader:
 
     def register(self, _loader):
         if _loader in self.loaders:
-            raise ValueError(f"{loader} is already a known loader.")
+            raise ValueError(f"{_loader} is already a known loader.")
         self.loaders.appendleft(_loader)
         return _loader
 
     def unregister(self, _loader):
         if _loader not in self.loaders:
-            raise ValueError(f"{loader} is not a known loader.")
+            raise ValueError(f"{_loader} is not a known loader.")
         self.loaders.remove(_loader)
 
     def __call__(self, base_uri) -> JSONSchema:

--- a/json_ref_dict/loader.py
+++ b/json_ref_dict/loader.py
@@ -28,7 +28,7 @@ except ImportError:  # pragma: no cover
 
 class Loader:
 
-    slots = ("loaders", "default")
+    __slots__ = ("loaders", "default")
 
     loaders: Deque[DocumentLoader]
 

--- a/json_ref_dict/materialize.py
+++ b/json_ref_dict/materialize.py
@@ -156,16 +156,15 @@ def _materialize_recursive(
         return None
     # Keep a record of walking this URI and recurse through the
     # contained items.
-    repeats[item.uri] = _RepeatCache(
-        source=JsonPointer(pointer), repeats=set())
+    repeats[item.uri] = _RepeatCache(source=JsonPointer(pointer), repeats=set())
 
     def recur(seg, data):
         return _materialize_recursive(
             conf, repeats, _next_path(pointer)(parse_segment(seg)), data
         )
+
     if isinstance(item, RefList):
-        return [recur(str(idx), subitem)
-                for idx, subitem in enumerate(item)]
+        return [recur(str(idx), subitem) for idx, subitem in enumerate(item)]
     return {
         **conf.label(item),
         **{

--- a/json_ref_dict/materialize.py
+++ b/json_ref_dict/materialize.py
@@ -156,12 +156,16 @@ def _materialize_recursive(
         return None
     # Keep a record of walking this URI and recurse through the
     # contained items.
-    repeats[item.uri] = _RepeatCache(source=JsonPointer(pointer), repeats=set())
-    recur = lambda seg, data: _materialize_recursive(
-        conf, repeats, _next_path(pointer)(parse_segment(seg)), data
-    )
+    repeats[item.uri] = _RepeatCache(
+        source=JsonPointer(pointer), repeats=set())
+
+    def recur(seg, data):
+        return _materialize_recursive(
+            conf, repeats, _next_path(pointer)(parse_segment(seg)), data
+        )
     if isinstance(item, RefList):
-        return [recur(str(idx), subitem) for idx, subitem in enumerate(item)]
+        return [recur(str(idx), subitem)
+                for idx, subitem in enumerate(item)]
     return {
         **conf.label(item),
         **{

--- a/json_ref_dict/ref_pointer.py
+++ b/json_ref_dict/ref_pointer.py
@@ -36,7 +36,7 @@ class RefPointer(JsonPointer):
         ):
             return False, None
         remote_uri = self.uri.relative(doc["$ref"]).get(
-            *self.parts[parts_idx + 1 :]
+            *self.parts[parts_idx + 1:]
         )
         return True, resolve_uri(remote_uri)
 

--- a/json_ref_dict/ref_pointer.py
+++ b/json_ref_dict/ref_pointer.py
@@ -36,7 +36,7 @@ class RefPointer(JsonPointer):
         ):
             return False, None
         remote_uri = self.uri.relative(doc["$ref"]).get(
-            *self.parts[parts_idx + 1:]
+            *self.parts[parts_idx + 1 :]
         )
         return True, resolve_uri(remote_uri)
 

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -6,6 +6,7 @@ import pytest
 
 from json_ref_dict import resolve_uri, RefDict, RefPointer, URI
 from json_ref_dict.ref_dict import RefList
+from json_ref_dict.loader import loader
 
 
 TEST_DATA = {
@@ -88,19 +89,19 @@ TEST_DATA = {
 }
 
 
-def get_document(base_uri: str):
-    return TEST_DATA[base_uri]
-
-
-@pytest.fixture(scope="module", autouse=True)
-def override_loader():
-    patcher = patch("json_ref_dict.ref_pointer.get_document", get_document)
-    mock_loader = patcher.start()
-    yield mock_loader
-    patcher.stop()
-
-
 class TestResolveURI:
+
+    @classmethod
+    def setup_class(cls):
+
+        @loader.register
+        def get_document(base_uri: str):
+            return TEST_DATA[base_uri]
+
+    @classmethod
+    def teardown_class(cls):
+        loader.loaders.clear()
+
     @staticmethod
     def test_get_no_ref():
         uri = URI.from_string("base/file1.json#/definitions/foo")
@@ -205,6 +206,18 @@ class TestResolveURI:
 
 
 class TestRefDict:
+
+    @classmethod
+    def setup_class(cls):
+
+        @loader.register
+        def get_document(base_uri: str):
+            return TEST_DATA[base_uri]
+
+    @classmethod
+    def teardown_class(cls):
+        loader.loaders.clear()
+
     @staticmethod
     @pytest.fixture(scope="class")
     def ref_dict():
@@ -292,6 +305,18 @@ class TestRefDict:
 
 
 class TestFromURI:
+
+    @classmethod
+    def setup_class(cls):
+
+        @loader.register
+        def get_document(base_uri: str):
+            return TEST_DATA[base_uri]
+
+    @classmethod
+    def teardown_class(cls):
+        loader.loaders.clear()
+
     @staticmethod
     def test_from_uri_list():
         ref_list = RefDict.from_uri("base/from-uri.json#/array")
@@ -326,6 +351,18 @@ class TestFromURI:
 
 
 class TestRefPointer:
+
+    @classmethod
+    def setup_class(cls):
+
+        @loader.register
+        def get_document(base_uri: str):
+            return TEST_DATA[base_uri]
+
+    @classmethod
+    def teardown_class(cls):
+        loader.loaders.clear()
+
     @staticmethod
     @pytest.fixture(scope="class")
     def uri() -> URI:
@@ -334,7 +371,7 @@ class TestRefPointer:
     @staticmethod
     @pytest.fixture(scope="class")
     def document(uri: URI) -> Dict[str, Any]:
-        return get_document(uri.root)
+        return loader(uri.root)
 
     @staticmethod
     @pytest.mark.parametrize("method", ["resolve", "get"])
@@ -435,5 +472,5 @@ class TestRefPointer:
         uri = URI.from_string(
             "base/ref-to-primitive.json#/top/ref_to_primitive"
         )
-        document = get_document(uri.root)
+        document = loader(uri.root)
         assert RefPointer(uri).resolve(document) == "foo"

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -87,19 +87,18 @@ TEST_DATA = {
 }
 
 
+@pytest.fixture(scope="module", autouse=True)
+def override_loader():
+    @loader.register
+    def _get_document(base_uri: str):
+        return TEST_DATA[base_uri]
+    try:
+        yield
+    finally:
+        loader.clear()
+
+
 class TestResolveURI:
-
-    @classmethod
-    def setup_class(cls):
-
-        # pylint:disable=unused-variable
-        @loader.register
-        def get_document(base_uri: str):
-            return TEST_DATA[base_uri]
-
-    @classmethod
-    def teardown_class(cls):
-        loader.loaders.clear()
 
     @staticmethod
     def test_get_no_ref():
@@ -206,18 +205,6 @@ class TestResolveURI:
 
 class TestRefDict:
 
-    @classmethod
-    def setup_class(cls):
-
-        # pylint:disable=unused-variable
-        @loader.register
-        def get_document(base_uri: str):
-            return TEST_DATA[base_uri]
-
-    @classmethod
-    def teardown_class(cls):
-        loader.loaders.clear()
-
     @staticmethod
     @pytest.fixture(scope="class")
     def ref_dict():
@@ -306,18 +293,6 @@ class TestRefDict:
 
 class TestFromURI:
 
-    @classmethod
-    def setup_class(cls):
-
-        # pylint:disable=unused-variable
-        @loader.register
-        def get_document(base_uri: str):
-            return TEST_DATA[base_uri]
-
-    @classmethod
-    def teardown_class(cls):
-        loader.loaders.clear()
-
     @staticmethod
     def test_from_uri_list():
         ref_list = RefDict.from_uri("base/from-uri.json#/array")
@@ -352,18 +327,6 @@ class TestFromURI:
 
 
 class TestRefPointer:
-
-    @classmethod
-    def setup_class(cls):
-
-        # pylint:disable=unused-variable
-        @loader.register
-        def get_document(base_uri: str):
-            return TEST_DATA[base_uri]
-
-    @classmethod
-    def teardown_class(cls):
-        loader.loaders.clear()
 
     @staticmethod
     @pytest.fixture(scope="class")

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -1,6 +1,4 @@
 from typing import Any, Dict, Iterable, Tuple, Union
-from unittest.mock import patch
-
 from jsonpointer import JsonPointer, JsonPointerException
 import pytest
 
@@ -94,6 +92,7 @@ class TestResolveURI:
     @classmethod
     def setup_class(cls):
 
+        # pylint:disable=unused-variable
         @loader.register
         def get_document(base_uri: str):
             return TEST_DATA[base_uri]
@@ -210,6 +209,7 @@ class TestRefDict:
     @classmethod
     def setup_class(cls):
 
+        # pylint:disable=unused-variable
         @loader.register
         def get_document(base_uri: str):
             return TEST_DATA[base_uri]
@@ -309,6 +309,7 @@ class TestFromURI:
     @classmethod
     def setup_class(cls):
 
+        # pylint:disable=unused-variable
         @loader.register
         def get_document(base_uri: str):
             return TEST_DATA[base_uri]
@@ -355,6 +356,7 @@ class TestRefPointer:
     @classmethod
     def setup_class(cls):
 
+        # pylint:disable=unused-variable
         @loader.register
         def get_document(base_uri: str):
             return TEST_DATA[base_uri]

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -5,7 +5,7 @@ from os import getcwd
 import pytest
 
 from json_ref_dict import RefDict
-from json_ref_dict.loader import loader
+from json_ref_dict.loader import loader, default_get_document
 from json_ref_dict.exceptions import DocumentParseError, ReferenceParseError
 
 
@@ -19,6 +19,9 @@ def test_loader_registration(request):
     """
     request.addfinalizer(loader.loaders.clear)
 
+    assert loader.default is default_get_document
+    assert not loader.loaders
+
     # pylint:disable=unused-argument
     @loader.register
     def useless(baseuri):
@@ -28,9 +31,15 @@ def test_loader_registration(request):
     loader.unregister(useless)
     assert list(loader) == []
 
+    with pytest.raises(ValueError) as exc:
+        loader.unregister(useless)
+    assert str(exc.value) == f'{useless} is not a known loader.'
+
     loader.register(useless)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc:
         loader.register(useless)
+    assert str(exc.value) == f'{useless} is already a known loader.'
+
 
     loader.loaders.clear()
     assert list(loader) == []

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -14,11 +14,31 @@ PINNED_FILE_URL = (
     "c19989a95449df587b62abea89aeb83676/tests/schemas/master.yaml"
 )
 
+def test_loader_registration(request):
+    """Tests the loaders iterable management
+    """
+    request.addfinalizer(loader.loaders.clear)
+
+    # pylint:disable=unused-argument
+    @loader.register
+    def useless(baseuri):
+        return ...
+
+    assert list(loader) == [useless]
+    loader.unregister(useless)
+    assert list(loader) == []
+
+    loader.register(useless)
+    with pytest.raises(ValueError):
+        loader.register(useless)
+
+    loader.loaders.clear()
+    assert list(loader) == []
+
 
 def test_loader_registration_chain(request):
     """Tests LIFO registration
     """
-
     request.addfinalizer(loader.loaders.clear)
 
     @loader.register

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -5,7 +5,7 @@ from os import getcwd
 import pytest
 
 from json_ref_dict import RefDict
-from json_ref_dict.loader import loader, default_get_document
+from json_ref_dict.loader import loader
 from json_ref_dict.exceptions import DocumentParseError, ReferenceParseError
 
 
@@ -17,10 +17,9 @@ PINNED_FILE_URL = (
 def test_loader_registration(request):
     """Tests the loaders iterable management
     """
-    request.addfinalizer(loader.loaders.clear)
+    request.addfinalizer(loader.clear)
 
-    assert loader.default is default_get_document
-    assert not loader.loaders
+    assert not list(loader)
 
     # pylint:disable=unused-argument
     @loader.register
@@ -41,14 +40,14 @@ def test_loader_registration(request):
     assert str(exc.value) == f'{useless} is already a known loader.'
 
 
-    loader.loaders.clear()
+    loader.clear()
     assert list(loader) == []
 
 
 def test_loader_registration_chain(request):
     """Tests LIFO registration
     """
-    request.addfinalizer(loader.loaders.clear)
+    request.addfinalizer(loader.clear)
 
     @loader.register
     def no_remote(baseuri):


### PR DESCRIPTION
Any related Github Issues?: _https://github.com/jacksmith15/json-ref-dict/issues/22_ 

`get_document` can now delegate the loading of a document to loaders. `loaders` are registerable and can be chained until a document is actually loaded. This allows several usecases : user/password secured URL, local schema registry, special file handling... The change is backward compatible and shouldn't impact existing deployments.

# Check list

## Before asking for a review

- [x] Target branch is `master`
- [x] `make test` passes locally.
- [x] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [x] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [ ] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [ ] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.