### PR TITLE
Escape URI parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Types of changes are:
 * **Fixed** for any bug fixes.
 
 ## [Unreleased]
+* Fixed recursive references with slashes in key names
 
 ## [0.6.2] - 2021-04-01
 ### Fixed

--- a/json_ref_dict/ref_pointer.py
+++ b/json_ref_dict/ref_pointer.py
@@ -7,7 +7,7 @@ from jsonpointer import JsonPointer, JsonPointerException, _nothing
 
 from json_ref_dict.exceptions import DocumentParseError
 from json_ref_dict.loader import get_document
-from json_ref_dict.uri import URI
+from json_ref_dict.uri import URI, parse_segment
 
 
 class RefPointer(JsonPointer):
@@ -36,7 +36,7 @@ class RefPointer(JsonPointer):
         ):
             return False, None
         remote_uri = self.uri.relative(doc["$ref"]).get(
-            *self.parts[parts_idx + 1 :]
+            *[parse_segment(part) for part in self.parts[parts_idx + 1 :]]
         )
         return True, resolve_uri(remote_uri)
 

--- a/tests/schemas/slash-key.yaml
+++ b/tests/schemas/slash-key.yaml
@@ -1,5 +1,13 @@
 definitions:
   bar/baz:
     type: integer
+  key_with_slashpath:
+    foo/bar:
+      baz:
+        type: integer
+  nested_reference:
+    $ref: '#/definitions/key_with_slashpath'
   slash_key:
     $ref: '#/definitions/bar~1baz'
+  slash_key_recursion:
+    $ref: '#/definitions/nested_reference'

--- a/tests/test_materialize.py
+++ b/tests/test_materialize.py
@@ -139,6 +139,9 @@ def test_materialize_slash_key():
     assert dictionary == {
         "definitions": {
             "bar/baz": {"type": "integer"},
+            "key_with_slashpath": {"foo/bar": {"baz": {"type": "integer"}}},
+            "nested_reference": {"foo/bar": {"baz": {"type": "integer"}}},
             "slash_key": {"type": "integer"},
+            "slash_key_recursion": {"foo/bar": {"baz": {"type": "integer"}}},
         }
     }


### PR DESCRIPTION
When references are being resolved, key names with
slashes in the reference URI pointers need to be escaped
to avoid misinterpretation.

ref-pointer did not escape the keys when handling
recursive references. Added parse_segement calls for
https://tools.ietf.org/html/rfc6901 escaping.

# Check list

## Before asking for a review

- [X] Target branch is `master`
- [X] `make test` passes locally.
- [X] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [X] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [ ] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [ ] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.