### PR TITLE
Bugfix/update with remote uris

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Types of changes are:
 
 ## [Unreleased]
 
+* Fixed recursive references pointing to remote documents.
+  References with ref_pointer can recurse to new remote
+  documents. ref_dict URIs need to be updated to point
+  to remote documents for the relative URI resolving to
+  work.
+
 ## [0.7.0] - 2021-05-24
 ### Changed
 * `get_document` can now delegate the loading of a document to loaders.

--- a/json_ref_dict/ref_dict.py
+++ b/json_ref_dict/ref_dict.py
@@ -1,14 +1,14 @@
 from collections import UserDict, UserList
 from typing import Any, Union
 
-from json_ref_dict.ref_pointer import resolve_remote_uri, UriValuePair
+from json_ref_dict.ref_pointer import resolve_uri_to_urivalue_pair, UriValuePair
 from json_ref_dict.uri import parse_segment, URI
 
 
 def _resolve_uri(uri: Union[str, URI]) -> UriValuePair:
     """Recurse to the value with the given URI as a starting point"""
     uri = URI.from_string(uri) if isinstance(uri, str) else uri
-    return resolve_remote_uri(uri)
+    return resolve_uri_to_urivalue_pair(uri)
 
 
 class RefDict(UserDict):  # pylint: disable=too-many-ancestors

--- a/json_ref_dict/ref_dict.py
+++ b/json_ref_dict/ref_dict.py
@@ -1,8 +1,14 @@
 from collections import UserDict, UserList
 from typing import Any, Union
 
-from json_ref_dict.ref_pointer import resolve_uri
+from json_ref_dict.ref_pointer import resolve_remote_uri, UriValuePair
 from json_ref_dict.uri import parse_segment, URI
+
+
+def _resolve_uri(uri: Union[str, URI]) -> UriValuePair:
+    """Recurse to the value with the given URI as a starting point"""
+    uri = URI.from_string(uri) if isinstance(uri, str) else uri
+    return resolve_remote_uri(uri)
 
 
 class RefDict(UserDict):  # pylint: disable=too-many-ancestors
@@ -15,8 +21,7 @@ class RefDict(UserDict):  # pylint: disable=too-many-ancestors
 
     def __init__(self, uri: Union[str, URI], *args, **kwargs):
         """On instantiation, retrieve the data from the URI."""
-        self.uri = URI.from_string(uri) if isinstance(uri, str) else uri
-        value = resolve_uri(self.uri)
+        self.uri, value = _resolve_uri(uri)
         if not isinstance(value, dict):
             raise TypeError(
                 f"The value at '{uri}' is not an object. Got '{value}'."
@@ -38,8 +43,7 @@ class RefDict(UserDict):  # pylint: disable=too-many-ancestors
         Looks ahead at the raw value, and then returns a RefDict, RefList, or
         other value.
         """
-        uri = URI.from_string(uri) if isinstance(uri, str) else uri
-        value = resolve_uri(uri)
+        uri, value = _resolve_uri(uri)
         if isinstance(value, dict):
             return RefDict(uri)
         if isinstance(value, list):
@@ -57,8 +61,7 @@ class RefList(UserList):  # pylint: disable=too-many-ancestors
 
     def __init__(self, uri: Union[str, URI], *args, **kwargs):
         """On instantiation, retrieve the data from the URI."""
-        self.uri = URI.from_string(uri) if isinstance(uri, str) else uri
-        value = resolve_uri(self.uri)
+        self.uri, value = _resolve_uri(uri)
         if not isinstance(value, list):
             raise TypeError(
                 f"The value at '{uri}' is not an array. Got '{value}'."

--- a/json_ref_dict/ref_pointer.py
+++ b/json_ref_dict/ref_pointer.py
@@ -9,7 +9,8 @@ from json_ref_dict.exceptions import DocumentParseError
 from json_ref_dict.loader import get_document
 from json_ref_dict.uri import URI, parse_segment
 
-UriValuePair = Tuple[URI, Union[List, Dict, None, bool, str, int, float]]
+ResolvedValue = Union[List, Dict, None, bool, str, int, float]
+UriValuePair = Tuple[URI, ResolvedValue]
 
 
 class RefPointer(JsonPointer):
@@ -129,10 +130,8 @@ class RefPointer(JsonPointer):
 
 
 @lru_cache(maxsize=None)
-def resolve_remote_uri(
-    uri: URI
-) -> Tuple[URI, Union[List, Dict, None, bool, str, int, float]]:
-    """Find the value for a given URI.
+def resolve_remote_uri(uri: URI) -> UriValuePair:
+    """Find the URI and document value for a given starting URI.
 
     Loads the document and resolves the pointer, bypassing refs.
     Utilises `lru_cache` to avoid re-loading multiple documents.
@@ -149,6 +148,10 @@ def resolve_remote_uri(
     return remote_uri if remote_uri else uri, value
 
 
-def resolve_uri(uri: URI) -> Union[List, Dict, None, bool, str, int, float]:
+def resolve_uri(uri: URI) -> ResolvedValue:
+    """Find the value for a given URI.
+
+    Loads the document and resolves the pointer, bypassing refs.
+    """
     _, value = resolve_remote_uri(uri)
     return value

--- a/tests/schemas/recursive_depth0.yaml
+++ b/tests/schemas/recursive_depth0.yaml
@@ -1,0 +1,3 @@
+definitions:
+  local_ref:
+    $ref: "./recursive_depth1.yaml#/definitions1/depth1foo"

--- a/tests/schemas/recursive_depth1.yaml
+++ b/tests/schemas/recursive_depth1.yaml
@@ -1,0 +1,3 @@
+definitions1:
+  depth1foo:
+    $ref: "./recursive_depth2.yaml#/definitions2/depth2foo"

--- a/tests/schemas/recursive_depth2.yaml
+++ b/tests/schemas/recursive_depth2.yaml
@@ -1,0 +1,6 @@
+definitions2:
+  depth2foo:
+    sublevel:
+      $ref: "#/definitions2/baz"
+  baz:
+    type: string

--- a/tests/test_materialize.py
+++ b/tests/test_materialize.py
@@ -90,7 +90,7 @@ def test_materialize_name_label():
             "foo": {"type": "string", "title": "foo"},
             "local_ref": {"type": "string", "title": "foo"},
             "remote_ref": {"type": "integer", "title": "bar"},
-            "backref": {"type": "string", "title": "baz"},
+            "backref": {"type": "string", "title": "foo"},
         },
         "title": "#",
     }
@@ -118,7 +118,7 @@ def test_materialize_uri_label():
             },
             "backref": {
                 "type": "string",
-                "uri": "tests/schemas/other.yaml#/definitions/baz",
+                "uri": "tests/schemas/master.yaml#/definitions/foo",
             },
         },
     }
@@ -130,6 +130,15 @@ def test_materialize_name_label_circular():
     assert isinstance(dictionary, dict)
     assert dictionary["definitions"]["title"] == "definitions"
     assert dictionary["definitions"]["foo"]["title"] == "#"
+
+
+def test_materialize_recursive_files():
+    ref_dict = RefDict("tests/schemas/recursive_depth0.yaml#/")
+    dictionary = materialize(ref_dict)
+    assert isinstance(dictionary, dict)
+    assert dictionary == {
+        "definitions": {"local_ref": {"sublevel": {"type": "string"}}}
+    }
 
 
 def test_materialize_slash_key():


### PR DESCRIPTION
Any related Github Issues?: https://github.com/jacksmith15/json-ref-dict/issues/14

_What has changed? This should mimic `CHANGELOG.md`._

If the URI and doc value are out of sync, relative references with URI cannot be
found in the document. The fix updates the URI that is stored in ref_dict when
reference recursion jumps to a new remote document.

# Check list

## Before asking for a review

- [X] Target branch is `master`
- [X] `make test` passes locally.
- [X] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [X] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [x] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [x] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.