### PR TITLE
Fix CGI dependancy for Python 3.11 <

### DIFF
--- a/json_ref_dict/loader.py
+++ b/json_ref_dict/loader.py
@@ -1,4 +1,4 @@
-import cgi
+from email.message import Message
 import os
 import pathlib
 import posixpath
@@ -139,7 +139,10 @@ def _get_content_type(conn) -> str:
     content_type = mimetypes.guess_type(conn.url)[0] or ""
     if hasattr(conn, "getheaders"):
         content_type = dict(conn.getheaders()).get("Content-Type", content_type)
-    return cgi.parse_header(content_type)[0]
+
+    msg = Message()
+    msg['content-type'] = content_type
+    return msg.get_content_type()
 
 
 # Can possibly be hotswitched by patching.


### PR DESCRIPTION
[ModuleNotFoundError: No module named 'cgi' ](https://github.com/jacksmith15/json-ref-dict/issues/29)